### PR TITLE
removed urldecode() to fix problem with encoded URLs

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -32,7 +32,7 @@
         }
 
         $shorturl = $_REQUEST['shorturl'];
-        $url = urldecode($_REQUEST['url']);
+        $url = $_REQUEST['url'];
 
         if ( yourls_get_protocol( $shorturl ) ) {
             $keyword = yourls_get_relative_url( $shorturl );
@@ -78,7 +78,7 @@
             );
         }
 
-        $url = urldecode($_REQUEST['url']);
+        $url = $_REQUEST['url'];
         $url_exists = yourls_url_exists($url);
 
         if ( $url_exists ) {


### PR DESCRIPTION
Thanks for your plugin! 
While playing with URLs with URL encoded whitespace (+) they were not found in database. The solution was to remove the urldecode() from the request vars. Please see the note here: http://php.net/manual/en/function.urldecode.php